### PR TITLE
Implement camera to follow player

### DIFF
--- a/Andesite2.0/src/Assets/map.tmx
+++ b/Andesite2.0/src/Assets/map.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.5.0" orientation="orthogonal" renderorder="right-down" width="500" height="35" tilewidth="32" tileheight="32" infinite="0" nextlayerid="29" nextobjectid="135">
+<map version="1.5" tiledversion="1.5.0" orientation="orthogonal" renderorder="right-down" width="500" height="35" tilewidth="32" tileheight="32" infinite="0" nextlayerid="29" nextobjectid="139">
  <tileset firstgid="1" name="Spritesheet_tileset" tilewidth="32" tileheight="32" tilecount="3136" columns="56">
   <image source="images/Spritesheet_tileset.png" width="1792" height="1792"/>
  </tileset>
@@ -319,10 +319,10 @@
  <objectgroup id="20" name="StaticCollisionLayer2">
   <object id="58" type="39" gid="3176" x="-32" y="640" width="256" height="256"/>
   <object id="75" type="43" gid="3180" x="480" y="896" width="256" height="256"/>
-  <object id="80" type="50" gid="3187" x="776" y="648" width="256" height="256"/>
+  <object id="80" type="50" gid="3187" x="736" y="608" width="256" height="256"/>
   <object id="82" type="51" gid="3188" x="1120" y="864" width="256" height="256"/>
   <object id="81" type="51" gid="3188" x="1120" y="1120" width="256" height="256"/>
-  <object id="84" type="50" gid="3187" x="1120" y="614" width="256" height="256"/>
+  <object id="84" type="50" gid="3187" x="1120" y="608" width="256" height="256"/>
   <object id="86" type="43" gid="3180" x="-164" y="548" width="256" height="256"/>
   <object id="88" type="39" gid="3176" x="224" y="640" width="256" height="256"/>
   <object id="89" type="40" gid="3177" x="480" y="640" width="256" height="256"/>
@@ -330,15 +330,7 @@
   <object id="107" type="51" gid="3188" x="1504" y="832" width="256" height="256"/>
   <object id="108" type="51" gid="3188" x="1504" y="1082" width="256" height="256"/>
   <object id="109" type="50" gid="3187" x="1504" y="576" width="256" height="256"/>
-  <object id="111" type="51" gid="3188" x="1504" y="1344" width="256" height="256"/>
-  <object id="112" type="51" gid="3188" x="1888" y="768" width="256" height="256"/>
-  <object id="113" type="51" gid="3188" x="1888" y="1018" width="256" height="256"/>
-  <object id="114" type="50" gid="3187" x="1888" y="512" width="256" height="256"/>
-  <object id="115" type="51" gid="3188" x="1888" y="1280" width="256" height="256"/>
-  <object id="116" type="51" gid="3188" x="2208" y="736" width="256" height="256"/>
-  <object id="117" type="51" gid="3188" x="2208" y="922" width="256" height="256"/>
-  <object id="118" type="50" gid="3187" x="2208" y="480" width="256" height="256"/>
-  <object id="119" type="51" gid="3188" x="2208" y="1184" width="256" height="256"/>
+  <object id="119" type="51" gid="3188" x="2208" y="1152" width="256" height="256"/>
   <object id="120" type="51" gid="3188" x="2624" y="1024" width="256" height="256"/>
   <object id="121" type="51" gid="3188" x="2624" y="1274" width="256" height="256"/>
   <object id="122" type="50" gid="3187" x="2624" y="768" width="256" height="256"/>
@@ -353,6 +345,10 @@
   <object id="132" type="41" gid="3178" x="2976" y="1280" width="256" height="256"/>
   <object id="133" type="43" gid="3180" x="4256" y="1280" width="256" height="256"/>
   <object id="134" type="43" gid="3180" x="4256" y="1024" width="256" height="256"/>
+  <object id="135" type="51" gid="3188" x="1856" y="1050" width="256" height="256"/>
+  <object id="136" type="51" gid="3188" x="1856" y="800" width="256" height="256"/>
+  <object id="137" type="50" gid="3187" x="1856" y="544" width="256" height="256"/>
+  <object id="138" type="50" gid="3187" x="2208" y="896" width="256" height="256"/>
  </objectgroup>
  <layer id="26" name="Tile Layer 3" width="500" height="35">
   <data encoding="csv">

--- a/Andesite2.0/src/Camera/Camera.cpp
+++ b/Andesite2.0/src/Camera/Camera.cpp
@@ -6,6 +6,8 @@ Camera* Camera::instance = nullptr;
 Camera::Camera() {
 	viewBox = { 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT };
 	pointTarget = nullptr;
+	MAP_WIDTH = 0;
+	MAP_HEIGHT = 0;
 }
 
 Camera::~Camera() {
@@ -24,15 +26,18 @@ void Camera::Update(float deltaTime) {
 	{
 		viewBox.x = 0;
 	}
-	if (viewBox.y < 0) {
+	if (viewBox.y < 0)
+	{
 		viewBox.y = 0;
 	}
 
-	if (viewBox.x > (2 * SCREEN_WIDTH - viewBox.w)) {
-		viewBox.x = (2 * SCREEN_WIDTH - viewBox.w);
+	if (viewBox.x > (2 * MAP_WIDTH - viewBox.w)) 
+	{
+		viewBox.x = (2 * MAP_WIDTH - viewBox.w);
 	}
-	if (viewBox.y > (SCREEN_HEIGHT - viewBox.h)) {
-		viewBox.y = (SCREEN_HEIGHT - viewBox.h);
+	if (viewBox.y > (MAP_HEIGHT - viewBox.h)) 
+	{
+		viewBox.y = (MAP_HEIGHT - viewBox.h);
 	}
 
 	position = Vector2D(viewBox.x, viewBox.y);

--- a/Andesite2.0/src/Camera/Camera.h
+++ b/Andesite2.0/src/Camera/Camera.h
@@ -10,13 +10,13 @@ public:
 	inline SDL_Rect GetViewBox() { return viewBox; }
 	inline Vector2D GetPosition() { return position; }
 	inline void SetTarget(Vector2D* targetPoint) { pointTarget = targetPoint; }
-
+	inline void SetMapSize(int width, int height) { MAP_WIDTH = width; MAP_HEIGHT = height; }
 	void Update(float deltaTime); 
 
 private:
 	Camera();
-
-
+	
+	int MAP_WIDTH, MAP_HEIGHT;
 	Vector2D* pointTarget;
 	Vector2D position;
 	SDL_Rect viewBox;

--- a/Andesite2.0/src/Game.cpp
+++ b/Andesite2.0/src/Game.cpp
@@ -3,6 +3,7 @@
 #include "Map/MapParser.h"
 #include "Time/Timer.h"
 #include "Physics/Physics.h"
+#include "Camera/Camera.h"
 
 Game* Game::gameInstance = nullptr;
 
@@ -75,6 +76,8 @@ bool Game::Init(const char* TITLE, int xPos, int yPos, int w, int h, bool fullsc
 
 	playerProperties = new Properties("player_idle", 50, 685, 300, 300);
 	player = new Player(playerProperties);
+	Camera::GetInstance()->SetMapSize(gameMap->GetMapWidth(), gameMap->GetMapHeight());
+	Camera::GetInstance()->SetTarget(player->GetOrigin());
 
 	isRunning = true;
 	return isRunning;
@@ -90,6 +93,7 @@ void Game::Update() {
 	float deltaTime = Timer::GetInstance()->GetDeltaTime();
 	player->Update(deltaTime);
 	gameMap->Update();
+	Camera::GetInstance()->Update(deltaTime);
 }
 
 void Game::Render() {
@@ -118,6 +122,7 @@ void Game::Render() {
 void Game::Clean() {
 	delete playerProperties; 
 	delete player;
+	delete Camera::GetInstance();
 	delete InputManager::GetInstance();
 	MapParser::GetInstance()->Clean();
 	delete MapParser::GetInstance();

--- a/Andesite2.0/src/Graphics/TextureManager.cpp
+++ b/Andesite2.0/src/Graphics/TextureManager.cpp
@@ -2,6 +2,7 @@
 #include "SDL_image.h"
 #include "TextureManager.h"
 #include "../Constants.h"
+#include "../Camera/Camera.h"
 using namespace constants;
 
 TextureManager* TextureManager::textureManagerInstance = nullptr;
@@ -38,19 +39,22 @@ void TextureManager::Draw(std::string id, int x, int y, int width, int height, S
 
 void TextureManager::DrawFrame(std::string id, int x, int y, int width, int height, int row, int frame, SDL_RendererFlip flip) {
 	SDL_Rect srcRect = { width * frame, height * row, width, height };
-	SDL_Rect dstRect = { x, y, width, height };
+	Vector2D cam = Camera::GetInstance()->GetPosition();
+	SDL_Rect dstRect = { x - cam.x, y - cam.y, width, height };
 	SDL_RenderCopyEx(Game::GetInstance()->GetRenderer(), TextureManager::GetInstance()->textureMap[id], &srcRect, &dstRect, 0, nullptr, flip);
 }
 
 void TextureManager::DrawTile(std::string tileSetID, int tileSize, int x, int y, int row, int frame, SDL_RendererFlip flip) {
 	SDL_Rect srcRect = { tileSize * frame, tileSize * row, tileSize, tileSize };
-	SDL_Rect dstRect = { x, y, tileSize, tileSize };
+	Vector2D cam = Camera::GetInstance()->GetPosition();
+	SDL_Rect dstRect = { x - cam.x, y - cam.y, tileSize, tileSize };
 	SDL_RenderCopyEx(Game::GetInstance()->GetRenderer(), textureMap[tileSetID], &srcRect, &dstRect, 0, 0, flip);
 }
 
 void TextureManager::DrawStaticTileObject(int imgWidth, int imgHeight, int x, int y, int typeID, SDL_RendererFlip flip) {
 	SDL_Rect srcRect = { 0, 0, imgWidth, imgHeight };
-	SDL_Rect dstRect = { x, y, imgWidth, imgHeight};
+	Vector2D cam = Camera::GetInstance()->GetPosition();
+	SDL_Rect dstRect = { x - cam.x, y - cam.y, imgWidth, imgHeight};
 	SDL_RenderCopyEx(Game::GetInstance()->GetRenderer(), textureMap[std::to_string(typeID)], &srcRect, &dstRect, 0, 0, flip);
 }
 

--- a/Andesite2.0/src/Main.cpp
+++ b/Andesite2.0/src/Main.cpp
@@ -7,19 +7,18 @@
 #include <map>
 #include "Time/Timer.h"
 #include "Game.h"
+#include "Constants.h"
+using namespace constants;
 
-const int SCREENWIDTH = 640;
-const int SCREENHEIGHT = 480;
 const int XPOS = SDL_WINDOWPOS_UNDEFINED;
 const int YPOS = SDL_WINDOWPOS_UNDEFINED;
-
  
 int main(int argc, char*args[])
 {
-	bool fullscreen = true;
+	bool fullscreen = false;
 
 	// Create and Initialize Game
-	Game::GetInstance()->Init("Andesite", XPOS, YPOS, SCREENWIDTH, SCREENHEIGHT, fullscreen);
+	Game::GetInstance()->Init("Andesite", XPOS, YPOS, SCREEN_WIDTH, SCREEN_HEIGHT, fullscreen);
 
 	// Game Loop
 	while (Game::GetInstance()->IsRunning() == true)
@@ -34,185 +33,3 @@ int main(int argc, char*args[])
 	delete Timer::GetInstance();
 	return 0;
 }
-
-
-
-// Add JSON file for Player data
-
-
-//const float M2P = 20;
-//const float P2M = 1 / M2P;
-//bool fullscreen = false;
-//SDL_Window* window;
-//SDL_Renderer* renderer;
-//b2World* physicsWorld;
-//
-//b2Body* addRect(int x, int y, int w, int h, bool dyn = true)
-//{
-//	b2BodyDef bodyDef;
-//	bodyDef.position.Set(x , y );
-//	if (dyn)
-//	{
-//		bodyDef.type = b2_dynamicBody;
-//	}
-//	b2Body* body = physicsWorld->CreateBody(&bodyDef);
-//	b2PolygonShape shape;
-//	shape.SetAsBox(w / 2,  h / 2);
-//	b2FixtureDef fixtureDef;
-//	fixtureDef.shape = &shape;
-//	fixtureDef.density = 1.0;
-//	body->CreateFixture(&fixtureDef);
-//
-//	return body;
-//}
-//
-//class Box {
-//	SDL_Rect rec
-//
-//		body = addRect(x, y, w, h, true);
-//	}
-//
-//
-//	void display() {
-//		rect.x = body->GetPosition().x;
-//		rect.y = body->GetPosition().y;
-//		SDL_RenderDrawRect(renderer, &rect);
-//		SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
-//		SDL_RenderFillRect(renderer, &rect);
-//	}
-//};
-//
-//void Init(const char* TITLE, int xPos, int yPos, int w, int h, bool fullscreen)
-//{
-//	int isFullScreen = 0;
-//	int imgTypeFlag = IMG_INIT_PNG;
-//	physicsWorld = new b2World(b2Vec2(0.0, 9.8)); // Create box2d world with 9.8 gravity
-//	addRect(SCREENWIDTH / 2, SCREENHEIGHT - 50, SCREENWIDTH, 30, false);
-//
-//	if (SDL_Init(SDL_INIT_EVERYTHING) == 0)
-//	{
-//		if (fullscreen)
-//		{
-//			isFullScreen = SDL_WINDOW_FULLSCREEN_DESKTOP;
-//		}
-//
-//		// Create Window
-//		window = SDL_CreateWindow(TITLE, xPos, yPos, w, h, isFullScreen);
-//		if (!window)
-//		{
-//			SDL_Log("Failed to create window: %s", SDL_GetError());
-//		}
-//
-//		// Create Renderer
-//		renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
-//		if (!renderer)
-//		{
-//			SDL_Log("Failed to create renderer: %s", SDL_GetError());
-//		}
-//
-//
-//		if (!(IMG_Init(imgTypeFlag) & imgTypeFlag))
-//		{
-//			SDL_Log("Failed to initialize SDL IMG: %s", IMG_GetError());
-//		}
-//	}
-//	else
-//	{
-//		SDL_Log("ERROR::GAME::INITIALIZE: Unable to initialize SDL: %s", SDL_GetError());
-//	}
-//}
-//
-//SDL_Texture* LoadTexture(std::string id, std::string filename) {
-//	SDL_Surface* surface = IMG_Load(filename.c_str());
-//
-//	if (surface == nullptr) {
-//		SDL_Log("Failed to load texture: %s, %s", filename.c_str(), SDL_GetError());
-//		return nullptr;
-//	}
-//
-//	SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, surface);
-//	if (texture == nullptr) {
-//		SDL_Log("Failed to create texture from surface: %s", SDL_GetError());
-//		return nullptr;
-//	}
-//
-//	SDL_FreeSurface(surface);
-//	surface = nullptr;
-//
-//	return texture;
-//}
-//
-//void render(std::vector<Box*> boxes,float dt)
-//{
-//	int velocityIterations = 6;
-//	int positionIterations = 2;
-//
-//	physicsWorld->Step(dt, velocityIterations, positionIterations);
-//
-//	// Render background
-//	const char* img_path = "src\\assets\\images\\Background.png";
-//	SDL_RenderClear(renderer);
-//	SDL_SetRenderDrawColor(renderer, 50, 50, 50, SDL_ALPHA_OPAQUE);
-//	SDL_Surface* surface = IMG_Load(img_path);
-//	SDL_Texture* background = SDL_CreateTextureFromSurface(renderer, surface);
-//	SDL_RenderCopy(renderer, background, NULL, NULL);
-//	
-//	for (int i = 0; i < boxes.size(); i++)
-//	{
-//		boxes[i]->display();
-//	}
-//
-//	SDL_FreeSurface(surface);
-//	SDL_RenderPresent(renderer);
-//}
-//
-//int main(int argc, char* args[])
-//{
-//	// Initialize Game
-//	Init("Andesite", XPOS, YPOS, SCREENWIDTH, SCREENHEIGHT, fullscreen);
-//	bool running = true;
-//	Uint32 start;
-//	SDL_Event event;
-//	std::vector<Box*> boxes;
-//	// Game Loop
-//	while (running)
-//	{
-//		Timer::GetInstance()->Tick();
-//		while (SDL_PollEvent(&event))
-//		{
-//			switch (event.type)
-//			{
-//				case SDL_QUIT:
-//					running = false;
-//					break;
-//
-//				case SDL_KEYDOWN:
-//					switch (event.key.keysym.sym)
-//					{
-//						case SDLK_ESCAPE:
-//							running = false;
-//							break;
-//					}
-//					break;
-//				case SDL_MOUSEBUTTONDOWN: 
-//					// addRect(event.button.x, event.button.y, 20, 20, true);
-//					boxes.push_back(new Box(event.button.x, event.button.y, 20, 20));
-//					break;
-//			default:
-//				break;
-//			}
-//		}
-//
-//		render(boxes, Timer::GetInstance()->GetDeltaTime());
-//	}
-//	
-//
-//	// Delete
-//	for (int i = 0; i < boxes.size(); i++)
-//	{
-//		delete boxes[i];
-//	}
-//	delete physicsWorld;
-//	delete Timer::GetInstance();
-//	return 0;
-//}

--- a/Andesite2.0/src/Map/GameMap.h
+++ b/Andesite2.0/src/Map/GameMap.h
@@ -10,7 +10,11 @@ public:
 	void Update(); 
 
 	inline std::vector<Layer*> GetMapLayers() { return mapLayers; }
+	inline int GetMapWidth() { return MAP_WIDTH; }
+	inline int GetMapHeight() { return MAP_HEIGHT; }
+
 private:
 	friend class MapParser;
 	std::vector<Layer*> mapLayers;
+	int MAP_WIDTH, MAP_HEIGHT;
 };

--- a/Andesite2.0/src/Map/MapParser.cpp
+++ b/Andesite2.0/src/Map/MapParser.cpp
@@ -41,6 +41,11 @@ bool MapParser::Parse(std::string id, std::string src) {
 	}
 	
 	GameMap* gameMap = new GameMap();
+	root->Attribute("width", &gameMap->MAP_WIDTH);
+	root->Attribute("height", &gameMap->MAP_HEIGHT);
+	gameMap->MAP_WIDTH *= tileSize;
+	gameMap->MAP_HEIGHT *= tileSize;
+
 	for (TiXmlElement* element = root->FirstChildElement(); element != nullptr; element = element->NextSiblingElement()) {
 		TileLayer* tileLayer;
 

--- a/Andesite2.0/src/Objects/GameObject.h
+++ b/Andesite2.0/src/Objects/GameObject.h
@@ -21,14 +21,22 @@ public:
 		:textureID(properties->textureID), 
 		position(properties->position),
 		width(properties->width), height(properties->height), renderFlip(properties->renderFlip) { 
+		float x = properties->position.x + properties->width / 2;
+		float y = properties->position.y + properties->height / 2;
+		origin = new Vector2D(x, y);
 	};
-	virtual ~GameObject() {};
+	virtual ~GameObject() {
+		delete origin;
+	};
+
+	inline Vector2D* GetOrigin() { return origin; }
 
 	virtual void Draw() = 0;
 	virtual void Update(float dt) = 0;
 	virtual void Clean() = 0;
 	
 protected:
+	Vector2D* origin;
 	Vector2D position; 
 	int width, height; 
 	std::string textureID; 

--- a/Andesite2.0/src/Objects/Player.cpp
+++ b/Andesite2.0/src/Objects/Player.cpp
@@ -25,12 +25,13 @@ Player::~Player() {
 
 void Player::Draw() {
 	animation->Draw(physicsBody->GetPosition().x * PIXEL_PER_METER - (width / 2) , physicsBody->GetPosition().y * PIXEL_PER_METER - (height / 3), width, height);
-
 }
 
 void Player::Update(float dt) {
 	animation->Update();
 	UpdateMovement();
+	origin->x = physicsBody->GetPosition().x * PIXEL_PER_METER + width / 2;
+	origin->y = physicsBody->GetPosition().y * PIXEL_PER_METER + height / 2;
 	// frame = (SDL_GetTicks() / animationSpeed) % frameCount; 
 }
 

--- a/Andesite2.0/src/Objects/Player.h
+++ b/Andesite2.0/src/Objects/Player.h
@@ -3,7 +3,7 @@
 #include "../Graphics/Animation.h"
 #include "../Physics/Physics.h"
 
-class Player : Actor {
+class Player : public Actor {
 public: 
 	Player() = default;
 	Player(Properties* properties);


### PR DESCRIPTION
# Context
A camera is required to allow the player to navigate the map beyond the threshold of the screen size. The camera follows the player and the view box will remain within the size of the map.

# Changes
- Player Actor has been set to public
- Map Height and Width are retrieved during map parsing and converted to pixels
- TextureManager draws tiles that are within the camera view box only
- Removed commented out code in main.cpp
- Set screen to not be fullscreen
- Change screen width and height in main.cpp to use constant values in Constants.h