### PR TITLE
Fix x location offset for collision box of right justified objects

### DIFF
--- a/Andesite2.0/src/Assets/map.tmx
+++ b/Andesite2.0/src/Assets/map.tmx
@@ -319,7 +319,7 @@
  <objectgroup id="20" name="StaticCollisionLayer2">
   <object id="58" type="39" gid="3176" x="-32" y="640" width="256" height="256"/>
   <object id="75" type="43" gid="3180" x="480" y="896" width="256" height="256"/>
-  <object id="80" type="50" gid="3187" x="736" y="608" width="256" height="256"/>
+  <object id="80" type="50" gid="3187" x="768" y="672" width="256" height="256"/>
   <object id="82" type="51" gid="3188" x="1120" y="864" width="256" height="256"/>
   <object id="81" type="51" gid="3188" x="1120" y="1120" width="256" height="256"/>
   <object id="84" type="50" gid="3187" x="1120" y="608" width="256" height="256"/>
@@ -340,7 +340,7 @@
   <object id="127" type="39" gid="3176" x="3744" y="768" width="256" height="256"/>
   <object id="128" type="39" gid="3176" x="4000" y="768" width="256" height="256"/>
   <object id="129" type="40" gid="3177" x="4256" y="768" width="256" height="256"/>
-  <object id="130" type="38" gid="3175" x="2976" y="764" width="256" height="256"/>
+  <object id="130" type="38" gid="3175" x="2976" y="768" width="256" height="256"/>
   <object id="131" type="41" gid="3178" x="2976" y="1024" width="256" height="256"/>
   <object id="132" type="41" gid="3178" x="2976" y="1280" width="256" height="256"/>
   <object id="133" type="43" gid="3180" x="4256" y="1280" width="256" height="256"/>

--- a/Andesite2.0/src/Map/MapParser.cpp
+++ b/Andesite2.0/src/Map/MapParser.cpp
@@ -1,4 +1,5 @@
 #include "../pch.h"
+#include <unordered_set>
 #include "MapParser.h"
 
 MapParser* MapParser::instance = nullptr;
@@ -161,6 +162,12 @@ TileLayer* MapParser::ParseStaticObjectCollisionLayer(TiXmlElement* xmlLayer, Ti
 	TileMap tileMap(numRow, std::vector<int>(numCol, 0));
 	TileLayer* tileLayer = new TileLayer(true, tileSize, numRow, numCol, tileMap, tileSets);
 
+	std::unordered_set<int> typeThatisRightJustifiedSet;
+	typeThatisRightJustifiedSet.insert(38);
+	typeThatisRightJustifiedSet.insert(44);
+	typeThatisRightJustifiedSet.insert(47);
+	typeThatisRightJustifiedSet.insert(41);
+
 	for (TiXmlElement* element = xmlLayer->FirstChildElement(); element != nullptr; element = element->NextSiblingElement()) {
 		if (element->Value() == std::string("object"))
 		{
@@ -188,7 +195,13 @@ TileLayer* MapParser::ParseStaticObjectCollisionLayer(TiXmlElement* xmlLayer, Ti
 				heightOffset = object.collisionHeight;
 			}
 			
-			object.physicsBody = Physics::GetInstance()->AddRect(object.x + (object.collisionWidth / 2), object.y + heightOffset, object.collisionWidth, object.collisionHeight, false);
+			int widthOffset = (object.collisionWidth / 2);
+			if (typeThatisRightJustifiedSet.find(object.typeID) != typeThatisRightJustifiedSet.end())
+			{
+				widthOffset = object.imageWidth - (object.collisionWidth / 2);
+			}
+
+			object.physicsBody = Physics::GetInstance()->AddRect(object.x + widthOffset, object.y + heightOffset, object.collisionWidth, object.collisionHeight, false);
 			
 			tileLayer->objects.push_back(object);
 		}


### PR DESCRIPTION
# Context
The collision box of objects that have empty space to the left of their visible sprite is not far enough right. Therefore, these type of objects that require an offset on the x-axis is stored in an unordered set so that the offset can be changed to the correct type of objects. 
# Changes
- Add x-axis offset for collision boxes of object types stored in unordered set